### PR TITLE
Update description if package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "speech-synthesis-recorder",
   "version": "1.0.0",
-  "description": "Record data instead of playing it from SpeechSynthesis.speak()",
+  "description": "Get audio output from window.speechSynthesis.speak() call as ArrayBuffer, AudioBuffer, Blob, MediaSource, MediaStream, ReadableStream, other object or data types",
   "main": "SpeechSynthesisRecorder.js",
   "scripts": {
     "test": "standard"


### PR DESCRIPTION
Substitute "Get audio output from window.speechSynthesis.speak() call as ArrayBuffer, AudioBuffer, Blob, MediaSource, MediaStream, ReadableStream, other object or data types" for  "Record data instead of playing it from SpeechSynthesis.speak()" at "description". .speak()   call currently requires output at speakers for MediaRecorder to record the audio.