### PR TITLE
chore: wrong params name

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ ttsRecorder.start()
 ```js
 let ttsRecorder = new SpeechSynthesisRecorder({
   text: "The revolution will not be televised", 
-  utternanceOptions: {
+  utteranceOptions: {
     voice: "english-us espeak",
     lang: "en-US",
     pitch: .75,


### PR DESCRIPTION
the `utternanceOptions` param should be named to `utteranceOptions`